### PR TITLE
Use custom namespace for asio to prevent UE collision

### DIFF
--- a/websocketpp/common/asio.hpp
+++ b/websocketpp/common/asio.hpp
@@ -71,7 +71,7 @@ namespace lib {
 
 #ifdef ASIO_STANDALONE
     namespace asio {
-        using namespace ::asio;
+        using namespace ::asio_sockio;
         // Here we assume that we will be using std::error_code with standalone
         // Asio. This is probably a good assumption, but it is possible in rare
         // cases that local Asio versions would be used.


### PR DESCRIPTION
This PR renames the namespace to `asio_sockio` to prevent a namespace collision when another version of asio is also being used in the same runtime (RE: https://github.com/getnamo/SocketIOClient-Unreal/issues/404)

Requires https://github.com/getnamo/asio/pull/1